### PR TITLE
chore: Remember endpoint in config

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -33,6 +33,7 @@ type APIClient struct {
 	RefreshToken     string
 	CurrentOrgSlug   string
 	CurrentWarehouse string
+	Endpoint         string
 }
 
 const (
@@ -52,6 +53,7 @@ func NewApiClient() *APIClient {
 		RefreshToken:     refreshToken,
 		CurrentOrgSlug:   config.GetOrg(),
 		CurrentWarehouse: config.GetWarehouse(),
+		Endpoint:         config.GetEndpoint(),
 	}
 }
 
@@ -118,6 +120,9 @@ func (c *APIClient) DoRequest(method, path string, headers http.Header, req inte
 
 func (c *APIClient) makeURL(path string, args ...interface{}) string {
 	apiEndpoint := os.Getenv("BENDSQL_API_ENDPOINT")
+	if apiEndpoint == "" {
+		apiEndpoint = c.Endpoint
+	}
 	if apiEndpoint == "" {
 		apiEndpoint = defaultApiEndpoint
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ const (
 	RefreshToken string = "refresh_token"
 	Warehouse    string = "warehouse"
 	Org          string = "org"
+	Endpoint     string = "endpoint"
 )
 
 const (
@@ -48,6 +49,7 @@ type Config struct {
 	RefreshToken string `ini:"refresh_token"`
 	Warehouse    string `ini:"warehouse"`
 	Org          string `ini:"org"`
+	Endpoint     string `init:"endpoint"`
 }
 
 type Configer interface {
@@ -90,7 +92,7 @@ func (c *Config) Write() error {
 	defaultSection.NewKey(Warehouse, c.Warehouse)
 	defaultSection.NewKey(Org, c.Org)
 	defaultSection.NewKey(UserEmail, c.UserEmail)
-
+	defaultSection.NewKey(Endpoint, c.Endpoint)
 	return cg.SaveTo(filepath.Join(ConfigDir(), bendsqlCinfigFile))
 }
 
@@ -179,6 +181,23 @@ func GetWarehouse() string {
 	return warehouse
 }
 
+func GetEndpoint() string {
+	if !Exists(filepath.Join(ConfigDir(), bendsqlCinfigFile)) {
+		return ""
+	}
+	cfg, err := NewConfig()
+	if err != nil {
+		logrus.Errorf("read config failed %v", err)
+		return ""
+	}
+	endpoint, err := cfg.Get(Endpoint)
+	if err != nil {
+		logrus.Errorf("get endpoint failed %v", err)
+		return ""
+	}
+	return endpoint
+}
+
 func GetUserEmail() string {
 	if !Exists(filepath.Join(ConfigDir(), bendsqlCinfigFile)) {
 		return ""
@@ -226,7 +245,7 @@ func ConfigDir() string {
 
 // Read bendsql configuration files from the local file system and
 // return a Config.
-var Read = func() (*Config, error) {
+func Read() (*Config, error) {
 	var err error
 	var iniCfg *ini.File
 	cfg := &Config{}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -16,7 +16,7 @@ package auth
 
 import (
 	"fmt"
-	"strconv"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
@@ -158,6 +158,10 @@ func loginRun(opts *LoginOptions) error {
 		cfg.Warehouse = warehouses[0].Name
 	}
 
+	if endpoint := os.Getenv("BENDSQL_API_ENDPOINT"); endpoint != "" {
+		cfg.Endpoint = endpoint
+	}
+
 	cfg.Org = apiClient.CurrentOrgSlug
 	cfg.AccessToken = apiClient.AccessToken
 	cfg.RefreshToken = apiClient.RefreshToken
@@ -168,8 +172,4 @@ func loginRun(opts *LoginOptions) error {
 
 	logrus.Infof("%s logged in %s of Databend Cloud successfully.", cfg.UserEmail, cfg.Org)
 	return nil
-}
-
-func mustString(accountID uint64) string {
-	return strconv.FormatInt(int64(accountID), 10)
 }


### PR DESCRIPTION
currently we can customize the api endpoint by envvar BENDSQL_API_ENDPOINT, however this envvar can not been memorized after auth.

this PR adds an `endpoint` field in the config file, and it can memorize the api endpoint after each auth success.